### PR TITLE
Add `input_list`, `output_list`, and `parameter_list` parameter to compute-command

### DIFF
--- a/datalad_compute/commands/tests/test_listhandling.py
+++ b/datalad_compute/commands/tests/test_listhandling.py
@@ -1,0 +1,25 @@
+import tempfile
+from pathlib import Path
+from datalad_compute.commands.compute_cmd import read_list
+
+from hypothesis import given
+from hypothesis.strategies import lists, text
+
+
+def test_empty_list_reading():
+    assert read_list(None) == []
+
+
+@given(lists(text('abcdefghijklmnopqrstuvwxyz _', min_size=1)))
+def test_list_reading(word_list):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        _test_wordlist(Path(temp_dir), word_list)
+
+
+def _test_wordlist(tmp_path: Path,
+                   word_list: list[str],
+                   ) -> None:
+    list_file = tmp_path / 'list.txt'
+    list_file.write_text('\n'.join(word_list))
+    assert read_list(str(list_file)) == word_list
+    assert read_list(list_file) == word_list

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -3,6 +3,7 @@ coverage
 datalad
 datalad-next
 datasalad
+hypothesis
 pytest
 pytest-cov
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,10 @@ include = datalad_compute*
 [options.extras_require]
 # this matches the name used by -core and what is expected by some CI setups
 devel =
+    coverage
+    hypothesis
     pytest
     pytest-cov
-    coverage
     sphinx
     sphinx_rtd_theme
     sphinx_copybutton


### PR DESCRIPTION
This PR amends the compute-command with new parameters. The new parameters allow the user to provide inputs, outputs and parameters by writing a list of inputs/outputs to a file and provide the file name to compute. This circumvents problems with too long command lines.
