### PR TITLE
Remove `dataset-id` from recompute-URLs

### DIFF
--- a/datalad_compute/annexremotes/tests/test_compute_remote.py
+++ b/datalad_compute/annexremotes/tests/test_compute_remote.py
@@ -83,8 +83,6 @@ def test_compute_remote_main(tmp_path, monkeypatch):
                 stdout=subprocess.PIPE,
                 check=True).stdout.splitlines()))[0].split(b': ')[1]
 
-    result = dataset.configuration('get', 'datalad.dataset.id')
-    dataset_id = result[0]['value']
     dataset_version = dataset.repo.get_hexsha()
 
     input = MockedInput()
@@ -96,8 +94,7 @@ def test_compute_remote_main(tmp_path, monkeypatch):
     input.send(f'TRANSFER RETRIEVE {key} {str(tmp_path / "computed.txt")}\n')
     url = (
         'datalad-make:///?'
-        f'root_id={dataset_id}'
-        f'&default_root_version={dataset_version}'
+        f'root_version={dataset.repo.get_hexsha()}'
         '&method=echo'
         '&input=%5B%5D'
         '&output=%5B"a.txt"%5D'

--- a/datalad_compute/commands/compute_cmd.py
+++ b/datalad_compute/commands/compute_cmd.py
@@ -194,8 +194,7 @@ def get_url(dataset: Dataset,
     branch = dataset.repo.get_hexsha() if branch is None else branch
     return (
         f'{url_scheme}:///'
-        + f'?root_id={quote(dataset.id)}'
-        + f'&default_root_version={quote(branch)}'
+        + f'&root_version={quote(branch)}'
         + f'&method={quote(template_name)}'
         + f'&input={quote(json.dumps(input_pattern))}'
         + f'&output={quote(json.dumps(output_pattern))}'


### PR DESCRIPTION
This PR shortens the recompute-URLs by removing the dataset-id parameter