### PR TITLE
Remove stale provision branches from datasets

### DIFF
--- a/datalad_compute/commands/provision_cmd.py
+++ b/datalad_compute/commands/provision_cmd.py
@@ -30,7 +30,7 @@ from datalad_next.constraints import (
     EnsureStr, EnsurePath,
 )
 from datalad_next.datasets import Dataset
-from datalad_next.runners import call_git_lines
+from datalad_next.runners import call_git_lines, call_git_success
 
 from datalad_compute.utils.glob import resolve_patterns
 from ..commands.compute_cmd import read_list
@@ -142,6 +142,9 @@ def remove(dataset: Dataset,
         recursive=True,
         result_renderer='disabled')
     prune_worktrees(dataset)
+    call_git_success(
+        ['branch', '-d', worktree.pathobj.name],
+        cwd=dataset.pathobj)
 
 
 def prune_worktrees(dataset: Dataset) -> None:

--- a/datalad_compute/commands/tests/test_provision.py
+++ b/datalad_compute/commands/tests/test_provision.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from contextlib import chdir
+import contextlib
+from contextlib import chdir, contextmanager
 from pathlib import Path
 from typing import Iterable
 
@@ -165,3 +166,19 @@ def test_unclean_dataset(tmp_path):
     dataset.provision(
         input=input_pattern,
         worktree_dir=tmp_path / 'ds1_worktree3')
+
+
+def test_branch_deletion_after_provision(tmp_path):
+    dataset = create_ds_hierarchy(tmp_path, 'ds1', 3)[0][2]
+    with provide_context(
+            dataset=dataset,
+            branch=None,
+            input_patterns=['a.txt']
+    ) as worktree:
+        assert worktree.exists()
+    assert not worktree.exists()
+    with contextlib.chdir(dataset.path):
+        branches = [
+            l.strip()
+            for l in call_git_lines(['branch'])]
+    assert worktree.name not in branches


### PR DESCRIPTION
This PR adds code that removes the branches from datasets that were created during provisioning. It also adds a regression test.