### PR TITLE
add an example for running fMRIprep in a singularity container

### DIFF
--- a/examples/fmriprep-singularity/fmriprep-singularity
+++ b/examples/fmriprep-singularity/fmriprep-singularity
@@ -1,0 +1,39 @@
+# This example template runs fMRIprep in a singularity container on a single
+# subject of a BIDS dataset.
+#
+# The template takes the following inputs:
+# - container: the path to fMRIprep singularity container image
+# - input_dir: the path to the input directory (BIDS dataset)
+# - output_dir: the path to the output directory
+# - participant_label: the label of the participant to be processed, e.g. `01`
+# - license_file: the path to the FreeSurfer license file
+#
+# The template assumes that the BIDS dataset referenced in `input_dir` is
+# a subdataset of the dataset in which the computation is started.
+#
+# Input files, output files, and parameter for the computation are defined in
+# the lists: `input.txt`, `output.txt`, and `parameter.txt` to keep the command
+# line short.
+#
+# `datalad compute -I input.txt -O output.txt -P parameter.txt fmriprep-singularity`
+
+inputs = ['container', 'input_dir', 'output_dir', 'participant_label', 'license_file']
+
+use_shell = 'false'
+executable = 'singularity'
+
+# Note: `{root_directory}` resolves to the directory of the dataset in which the
+# computation was started with `datalad compute`.
+
+arguments = [
+    'run', '{container}',
+    '{root_directory}/{input_dir}',
+    '{root_directory}/{output_dir}',
+    'participant',
+    '--participant-label', '{participant_label}',
+    '--sloppy',
+    '--fs-license-file', '{license_file}',
+    '--fs-no-reconall',
+    '--skip-bids-validation',
+    '--ignore', 'slicetiming',
+]

--- a/examples/fmriprep-singularity/fmriprep-singularity.md
+++ b/examples/fmriprep-singularity/fmriprep-singularity.md
@@ -1,0 +1,116 @@
+# Use case: running fMRIprep in a singularity container
+
+This example demonstrates how to run fMRIprep on a single subject of a BIDS dataset using a singularity container. Specifically, the singularity container used in this example is `bids-fmriprep--24.1.0` and comes from the [ReproNim containers collection](https://github.com/ReproNim/containers).
+
+The example comprises the following files:
+- `fmriprep-singularity` template
+- `input.txt` input specification
+- `output.txt` output specification
+- `parameter.txt` parameters
+
+## Requirements
+
+This example requires Singularity.
+
+Please note, that there is no need to install fMRIprep. The singularity container will be automatically retrieved from the ReproNim containers collection. However, in order to use fMRIprep you need to obtain a [FreeSurfer license](https://surfer.nmr.mgh.harvard.edu/fswiki/License). 
+
+It is assumed that the license file is located in `/tmp`. Make sure to copy it there or modify the `parameter.txt` file accordingly (see the [Add template](#add-template) section below).
+
+## How to install
+
+Install `datalad-compute` extension, as described [here](https://github.com/christian-monch/datalad-compute/tree/main?tab=readme-ov-file#installation).
+
+## How to use
+
+It is assumed that you have a local copy of `datalad-compute` repository in your `$HOME` directory. If this not the case, adjust the path below:
+
+```
+EXAMPLE=$HOME/datalad-compute/examples/fmriprep-singularity
+```
+
+### Create dataset
+
+Create a dataset, together with its subdatasets:
+
+```
+cd $HOME
+datalad create -c text2git my-project
+
+cd my-project
+
+datalad clone -d . https://github.com/ReproNim/containers code/containers
+datalad get -n code/containers
+
+datalad clone -d . https://github.com/OpenNeuroDatasets/ds000102 data/ds000102
+datalad get -n data/ds000102
+
+datalad create -d . derivatives/ds000102
+```
+
+The dataset used in this example is organized in a modular way. In particular, input data (`data/ds000102`) and output data (`derivatives/ds000102`) are tracked in separate subdatasets, as is the software container (`code/containers`).
+
+The resulting dataset structure is as follows:
+
+```
+my-project
+├── code
+│   └── containers
+├── data
+│   └── ds000102
+└── derivatives
+    └── ds000102
+```
+
+### Configure special remote
+
+Configure the dataset in which you want to collect the results of the (re)computation, in this case `derivatives/ds000102` subdataset.
+
+```
+cd $HOME/my-project/derivatives/ds000102
+```
+
+First, add the `compute` special remote:
+
+```
+git annex initremote compute type=external externaltype=compute encryption=none
+```
+
+Second, adjust git configuration:
+```
+git config annex.security.allowed-url-schemes datalad-make
+git config annex.security.allowed-ip-addresses all
+```
+
+### Add template
+
+Place the `fmriprep-singularity` template in the `.datalad/compute/methods` of the root dataset:
+
+```
+cd $HOME/my-project
+
+mkdir -p .datalad/compute/methods
+cp $EXAMPLE/fmriprep-singularity .datalad/compute/methods/fmriprep-singularity
+
+datalad save -m "Add a compute method"
+```
+
+Place the `input.txt`, `output.txt` and `parameter.txt` files in the root dataset. These files do not have to be tracked in git history, so no `datalad save` is required at this point.
+
+```
+cp $EXAMPLE/*.txt ./
+```
+
+### Execute (re)computation
+
+To test the example, run:
+
+```
+cd $HOME/my-project
+datalad compute -I input.txt -O output.txt -P parameter.txt fmriprep-singularity
+```
+
+You can also do that in `debug` mode:
+
+```
+datalad -l debug compute -I input.txt -O output.txt -P parameter.txt fmriprep-singularity
+```

--- a/examples/fmriprep-singularity/input.txt
+++ b/examples/fmriprep-singularity/input.txt
@@ -1,0 +1,7 @@
+# Paths are relative to the dataset in which `datalad compute` was executed
+data/ds000102/dataset_description.json
+data/ds000102/participants.tsv
+data/ds000102/T1w.json
+data/ds000102/task-flanker_bold.json
+data/ds000102/sub-01/**
+code/containers/images/bids/bids-fmriprep--24.1.0.sing

--- a/examples/fmriprep-singularity/output.txt
+++ b/examples/fmriprep-singularity/output.txt
@@ -1,0 +1,2 @@
+# Paths are relative to the dataset in which `datalad compute` was executed
+derivatives/ds000102/**

--- a/examples/fmriprep-singularity/parameter.txt
+++ b/examples/fmriprep-singularity/parameter.txt
@@ -1,0 +1,5 @@
+container=code/containers/images/bids/bids-fmriprep--24.1.0.sing
+input_dir=data/ds000102
+output_dir=derivatives/ds000102
+participant_label=01
+license_file=/tmp/license.txt


### PR DESCRIPTION
This PR adds an example for running fMRIprep in a singularity container. I have already tested it and everything seems to be working fine, but code review is welcome.

Things to consider:
- I decided to keep `datalad get -n` steps for now. However, this example works just fine without them.
- `fmriprep` call is currently parametrized with `--sloppy` flag. Should we mention that in the example description?