### PR TITLE
Use `datalad run`-like input globbing

### DIFF
--- a/datalad_compute/annexremotes/tests/test_hierarchies.py
+++ b/datalad_compute/annexremotes/tests/test_hierarchies.py
@@ -104,7 +104,7 @@ def test_end_to_end(tmp_path, datalad_cfg, monkeypatch, output_pattern):
     # Go to the subdataset `d2_subds0/d2_subds1` and fetch the content of `a1.txt`
     # from a compute remote.
     monkeypatch.chdir(root_dataset.pathobj / 'd2_subds0' / 'd2_subds1')
-    datalad_get('a1.txt')
+    datalad_get()('a1.txt')
 
     # check that all known files that were computed are added to the annex
     _check_content(root_dataset, test_file_content)
@@ -113,6 +113,6 @@ def test_end_to_end(tmp_path, datalad_cfg, monkeypatch, output_pattern):
 
     # check get in subdatasets
     monkeypatch.chdir(root_dataset.pathobj)
-    datalad_get('d2_subds0/d2_subds1/a1.txt')
+    datalad_get()('d2_subds0/d2_subds1/a1.txt')
 
     _check_content(root_dataset, test_file_content)

--- a/datalad_compute/commands/compute_cmd.py
+++ b/datalad_compute/commands/compute_cmd.py
@@ -129,12 +129,6 @@ class Compute(ValidatedInterface):
                 "that start with '#' are ignored. Line content is stripped "
                 "before used. This is useful if a large number of parameters "
                 "should be provided."),
-        no_globbing=Parameter(
-            args=('-n', '--no-globbing',),
-            doc="Use input pattern as file names and do not apply globbing. "
-                "This allows to specify files that are no currently present "
-                "in the source dataset as input. Those files will be made "
-                "available in the worktree."),
     )
 
     @staticmethod
@@ -150,7 +144,6 @@ class Compute(ValidatedInterface):
                  output_list=None,
                  parameter=None,
                  parameter_list=None,
-                 no_globbing=False,
                  ):
 
         dataset : Dataset = dataset.ds if dataset else Dataset('.')
@@ -178,7 +171,6 @@ class Compute(ValidatedInterface):
                     dataset,
                     branch,
                     input_pattern,
-                    no_globbing,
             ) as worktree:
                 execute(worktree, template, parameter_dict, output_pattern)
                 output = collect(worktree, dataset, output_pattern)
@@ -325,14 +317,12 @@ def get_file_dataset(file: Path) -> tuple[Path, Path]:
 def provide(dataset: Dataset,
             branch: str | None,
             input_patterns: list[str],
-            no_globbing: bool,
             ) -> Path:
 
     lgr.debug('provide: %s %s %s', dataset, branch, input_patterns)
     result = dataset.provision(
         input=input_patterns,
         branch=branch,
-        no_globbing=no_globbing,
         result_renderer='disabled')
     return Path(result[0]['path'])
 
@@ -341,14 +331,12 @@ def provide(dataset: Dataset,
 def provide_context(dataset: Dataset,
                     branch: str | None,
                     input_patterns: list[str],
-                    no_globbing: bool = False,
                     ) -> Generator:
 
     worktree = provide(
         dataset,
         branch=branch,
-        input_patterns=input_patterns,
-        no_globbing=no_globbing)
+        input_patterns=input_patterns)
     try:
         yield worktree
     finally:

--- a/datalad_compute/commands/compute_cmd.py
+++ b/datalad_compute/commands/compute_cmd.py
@@ -294,10 +294,10 @@ def add_url(dataset: Dataset,
             + (['--relaxed'] if url_only else []),
             cwd=file_dataset_path,
             capture_output=True)
-        assert (
-            success,
-            f'\naddurl failed:\nfile_dataset_path: {file_dataset_path}\n'
-            f'url: {url!r}\nfile_path: {file_path!r}')
+        assert \
+            success, \
+            f'\naddurl failed:\nfile_dataset_path: {file_dataset_path}\n' \
+            f'url: {url!r}\nfile_path: {file_path!r}'
     return url
 
 

--- a/datalad_compute/commands/provision_cmd.py
+++ b/datalad_compute/commands/provision_cmd.py
@@ -34,9 +34,7 @@ from datalad_next.constraints import (
 )
 from datalad_next.datasets import Dataset
 from datalad_next.runners import call_git_lines, call_git_success
-from hypothesis.strategies import recursive
 
-from datalad_compute.utils.glob import resolve_patterns
 from ..commands.compute_cmd import read_list
 
 
@@ -91,8 +89,9 @@ class Provision(ValidatedInterface):
             args=('-i', '--input',),
             action='append',
             doc="An input file pattern (repeat for multiple inputs, "
-                "file pattern support python globbing, globbing is expanded "
-                "in the source dataset"),
+                "file pattern support python globbing, globbing is done in the "
+                "worktree and through all matching subdatasets, installing "
+                "if necessary)."),
         input_list=Parameter(
             args=('-I', '--input-list',),
             doc="Name of a file that contains a list of input file patterns. "

--- a/datalad_compute/commands/tests/test_provision.py
+++ b/datalad_compute/commands/tests/test_provision.py
@@ -165,13 +165,6 @@ def test_unclean_dataset(tmp_path):
         worktree_dir=tmp_path / 'ds1_worktree2',
         result_renderer='disabled')
 
-    # Check that non-input file `c.txt` is ignored
-    (dataset.pathobj / 'c.txt').write_text('content')
-    dataset.provision(
-        input=input_pattern,
-        worktree_dir=tmp_path / 'ds1_worktree3',
-        result_renderer='disabled')
-
 
 def test_branch_deletion_after_provision(tmp_path):
     dataset = create_ds_hierarchy(tmp_path, 'ds1', 3)[0][2]

--- a/datalad_compute/commands/tests/test_provision.py
+++ b/datalad_compute/commands/tests/test_provision.py
@@ -5,6 +5,7 @@ from contextlib import chdir
 from pathlib import Path
 from typing import Iterable
 
+import pytest
 from datalad_next.datasets import Dataset
 from datalad_next.runners import call_git_lines
 
@@ -182,6 +183,7 @@ def test_branch_deletion_after_provision(tmp_path):
     assert worktree.name not in branches
 
 
+@pytest.mark.skip(reason="local subdatasets are currently ignored")
 def test_not_present_local_datasets(tmp_path):
     root_ds = Dataset(tmp_path / 'ds1')
     root_ds.create(cfg_proc='text2git', result_renderer='disabled')

--- a/datalad_compute/commands/tests/test_provision.py
+++ b/datalad_compute/commands/tests/test_provision.py
@@ -183,7 +183,6 @@ def test_branch_deletion_after_provision(tmp_path):
     assert worktree.name not in branches
 
 
-@pytest.mark.skip(reason="local subdatasets are currently ignored")
 def test_not_present_local_datasets(tmp_path):
     root_ds = Dataset(tmp_path / 'ds1')
     root_ds.create(cfg_proc='text2git', result_renderer='disabled')
@@ -206,7 +205,6 @@ def test_not_present_local_datasets(tmp_path):
     provisioned_dataset_2 = Dataset(
         root_ds.provision(
             input=['ds000102/README'],
-            no_globbing=True,
             on_failure='ignore',
             result_renderer='disabled')[0]['path'])
     url_2 = _get_submodule_url(provisioned_dataset_2, 'ds000102')


### PR DESCRIPTION
This PR adds input globbing that will automatically install all necessary subdatasets required to resolve input patterns.

The PR also removes the `-n/--no-globbing` option.
